### PR TITLE
Rule support

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,9 +74,8 @@ func (c *Client) hasError(response *http.Response) error {
 			return err
 		}
 
-		if err := json.Unmarshal(body, &apierror); err != nil {
-			apierror.Detail = string(body)
-		}
+		json.Unmarshal(body, &apierror)
+		apierror.Detail = string(body)
 
 		return error(apierror)
 	}

--- a/project.go
+++ b/project.go
@@ -41,8 +41,8 @@ type Project struct {
 	Plugins            *[]Plugin               `json:"plugins,omitempty"`
 	Team               *Team                   `json:"team,omitempty"`
 	Organization       *Organization           `json:"organization,omitempty"`
-	DigestMinDelay     *int                    `json:"digestMinDelay,omitempty"`
-	DigestMaxDelay     *int                    `json:"digestMaxDelay,omitempty"`
+	DigestsMinDelay    *int                    `json:"digestsMinDelay,omitempty"`
+	DigestsMaxDelay    *int                    `json:"digestsMaxDelay,omitempty"`
 }
 
 // CreateProject will create a new project in your org and team

--- a/rule.go
+++ b/rule.go
@@ -1,0 +1,47 @@
+package sentry
+
+import (
+	"fmt"
+	"time"
+)
+
+type Rule struct {
+	ActionMatch string      `json:"actionMatch"`
+	Actions     []Action    `json:"actions"`
+	Conditions  []Condition `json:"conditions"`
+	Name        string      `json:"name"`
+	Frequency   int         `json:"frequency"`
+	Id          string      `json:"id,omitempty"`
+	DateCreated time.Time   `json:"dateCreated,omitempty"`
+}
+
+type Action struct {
+	Id      string `json:"id"`
+	Service string `json:"service,omitempty"`
+}
+
+type Condition struct {
+	Id       string `json:"id"`
+	Interval string `json:"interval,omitempty"`
+	Value    string `json:"value,omitempty"`
+}
+
+// GetRules fetchs all rules for a given project
+func (c *Client) GetRules(o Organization, p Project) ([]Rule, error) {
+	var rules []Rule
+
+	err := c.do("GET", fmt.Sprintf("projects/%s/%s/rules", *o.Slug, *p.Slug), &rules, nil)
+	return rules, err
+}
+
+func (c *Client) CreateRule(o Organization, p Project, rule Rule) (Rule, error) {
+	var resRule Rule
+
+	err := c.do("POST", fmt.Sprintf("projects/%s/%s/rules", *o.Slug, *p.Slug), &resRule, &rule)
+	return resRule, err
+}
+
+func (c *Client) DeleteRule(o Organization, p Project, ruleId string) error {
+	err := c.do("DELETE", fmt.Sprintf("projects/%s/%s/rules/%s", *o.Slug, *p.Slug, ruleId), nil, nil)
+	return err
+}

--- a/rule.go
+++ b/rule.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -21,9 +22,11 @@ type Action struct {
 }
 
 type Condition struct {
-	Id       string `json:"id"`
-	Interval string `json:"interval,omitempty"`
-	Value    string `json:"value,omitempty"`
+	Id       string      `json:"id"`
+	Interval string      `json:"interval,omitempty"`
+	Value    json.Number `json:"value,omitempty"`
+	Key      string      `json:"key,omitempty"`
+	Match    string      `json:"match,omitempty"`
 }
 
 // GetRules fetchs all rules for a given project

--- a/rule_test.go
+++ b/rule_test.go
@@ -3,8 +3,6 @@ package sentry
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
 	"testing"
 )
 
@@ -54,17 +52,11 @@ func TestRuleResource(t *testing.T) {
 		}
 		`
 
-		for _, e := range os.Environ() {
-			pair := strings.Split(e, "=")
-			fmt.Println(pair)
-		}
-
 		rule := Rule{}
 		err = json.Unmarshal([]byte(ruleStr), &rule)
 		if err != nil {
 			t.Error(err)
 		}
-
 		fmt.Printf("%+v", rule)
 
 		newRule, err := client.CreateRule(org, project, rule)

--- a/rule_test.go
+++ b/rule_test.go
@@ -1,0 +1,119 @@
+package sentry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRuleResource(t *testing.T) {
+
+	client := newTestClient(t)
+	org, err := client.GetOrganization(getDefaultOrg())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	team, cleanup := createTeamHelper(t)
+	defer cleanup()
+
+	project, cleanupproj := createProjectHelper(t, team)
+	defer cleanupproj()
+
+	t.Run("Get all rules for a project", func(t *testing.T) {
+		rules, err := client.GetRules(org, project)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("Expected a single rule got %d rules", len(rules))
+		}
+
+		fmt.Printf("%+v", rules)
+
+		ruleStr := `
+		{
+		  "actionMatch": "all",
+		  "actions": [
+		    {
+		      "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+		      "service": "mail"
+		    }
+		  ],
+		  "conditions": [
+		    {
+		      "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+		      "interval": "1h",
+		      "value": "10"
+		    }
+		  ],
+		  "name": "Send Email for Error Burst",
+		  "frequency": 30
+		}
+		`
+
+		for _, e := range os.Environ() {
+			pair := strings.Split(e, "=")
+			fmt.Println(pair)
+		}
+
+		rule := Rule{}
+		err = json.Unmarshal([]byte(ruleStr), &rule)
+		if err != nil {
+			t.Error(err)
+		}
+
+		fmt.Printf("%+v", rule)
+
+		newRule, err := client.CreateRule(org, project, rule)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if newRule.Actions[0].Id != "sentry.rules.actions.notify_event_service.NotifyEventServiceAction" {
+			t.Errorf("Expected action to be NotifyEventServiceAction got %s", newRule.Actions[0].Id)
+		}
+
+		condition := newRule.Conditions[0]
+		if condition.Id != "sentry.rules.conditions.event_frequency.EventFrequencyCondition" {
+			t.Errorf("Expected condition to be EventFrequencyCondition got %s", condition.Id)
+		}
+
+		if condition.Interval != "1h" {
+			t.Errorf("Expected interval to be 1h got %s", condition.Interval)
+		}
+
+		if condition.Value != "10" {
+			t.Errorf("Expected value to be 10 got %s", condition.Value)
+		}
+
+		rules, err = client.GetRules(org, project)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(rules) != 2 {
+			t.Fatalf("Expected 2 rules got %d rules", len(rules))
+		}
+
+		err = client.DeleteRule(org, project, newRule.Id)
+		if err != nil {
+			t.Error(err)
+		}
+
+		rules, err = client.GetRules(org, project)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("Expected 1 rules got %d rules", len(rules))
+		}
+	})
+
+	if err := client.DeleteTeam(org, team); err != nil {
+		t.Error(err)
+	}
+
+}


### PR DESCRIPTION
@vladimir-sapronov-zocdoc @eugene-yao-zocdoc 

This adds initial support for the Rules (and alerts) api of sentry. So far this api isn't documented on their docs page https://docs.sentry.io/api/projects/ but one of their engineers pointed it out to me. My guess is that its not fully polished/stabilized yet and could change in future versions, but will serve our use case for now 